### PR TITLE
Adjust git command to find current branch name.

### DIFF
--- a/pubnpm
+++ b/pubnpm
@@ -154,7 +154,9 @@ if [ x"$BRANCH" = x ]; then
     echo "# NOTE: git branch check skipped via options"
   fi
 else
-  GIT_BRANCH=$(git branch --show-current)
+  # newer git
+  #GIT_BRANCH=$(git branch --show-current)
+  GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
   if [ x"$BRANCH" = x"$GIT_BRANCH" ]; then
     if [ "$VERBOSE" = true ]; then
       echo "# NOTE: git branch check passed"


### PR DESCRIPTION
Older git versions don't support "git branch --show-current".