### PR TITLE
Add npm publish access flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,18 @@ $ pubbower minor
 * `-t TAG` or `--tag=TAG`: Use the [npm publish](https://docs.npmjs.com/cli/publish) tag feature
 * `-b BRANCH` or `--branch=BRANCH`: Ensure running on a git branch (default: master, empty string to skip).
 * `-N` or `--new`: Skip owner check for a new package.
+* `-P` or `--public`: Used with `new` to specify that a scoped package is public.
+* `-R` or `--restricted`: Used with `new` to specify that a scoped package is private/restricted.
 
 **NOTE**: MacOS only supports short options.
 
 The tag feature is useful if releasing to a "dev" branch vs the "latest":
 
-```shell
-$ pubnpm -v -t dev patch
+```sh
+pubnpm -v -t dev patch
+```
+
+### Release a new public scoped package from the main branch
+```sh
+pubnpm -N -P -b main major
 ```

--- a/pubnpm
+++ b/pubnpm
@@ -283,9 +283,9 @@ if [ $(node -p "'build' in (require('./package.json').scripts || {})") = true ];
   run_cmd npm install
 fi
 if [ x"$TAG" = x ]; then
-  run_cmd npm publish
+  run_cmd npm publish --access public
 else
-  run_cmd npm publish --tag $TAG
+  run_cmd npm publish --tag $TAG --access public
 fi
 run_cmd cd ${PACKAGE_DIR}
 run_cmd npm version prepatch -m 'Start %s.'

--- a/pubnpm
+++ b/pubnpm
@@ -180,7 +180,7 @@ fi
 if [ "$NEW" = true ]; then
   if [ "$VERBOSE" = true ]; then
     echo "# $MSG_NOTE: skipping owner check"
-    echo "# $MSG_WARNING: new package, add more maintainrs!"
+    echo "# $MSG_WARNING: new package, add more maintainers!"
   fi
 else
   # check npm ownership access

--- a/pubnpm
+++ b/pubnpm
@@ -107,11 +107,11 @@ else
 fi
 
 if [ "$GNU_GETOPT" = true ]; then
-  OPTS=`getopt -o hvC:nt:b:N -l help,verbose,dry-run,tag:,branch:,new -n 'pubnpm' -- "$@"`
+  OPTS=`getopt -o hvC:nt:b:N:P:R -l help,verbose,dry-run,tag:,branch:,new,public,restricted -n 'pubnpm' -- "$@"`
   if [ $? != 0 ] ; then echo "ERROR: Failed parsing options." >&2 ; exit 1 ; fi
   eval set -- "$OPTS"
 else
-  OPTS=`getopt hvC:nt:b:N $*`
+  OPTS=`getopt hvC:nt:b:N:P:R $*`
   if [ $? != 0 ] ; then echo "ERROR: Failed parsing options." >&2 ; exit 1 ; fi
   eval set -- "$OPTS"
 fi
@@ -122,6 +122,7 @@ TAG=
 BRANCH=master
 NEW=false
 COLOR=${PUBNPM_COLOR:-auto}
+NPM_ACCESS=
 
 while true; do
   case "$1" in
@@ -132,6 +133,8 @@ while true; do
     -t|--tag) TAG="$2"; shift; shift ;;
     -b|--branch) BRANCH="$2"; shift; shift ;;
     -N|--new) NEW=true; shift ;;
+    -P|--public) NPM_ACCESS=public; shift ;;
+    -R|--restricted) NPM_ACCESS=restricted; shift ;;
     --) shift; break ;;
     *) break ;;
   esac
@@ -178,6 +181,14 @@ if [ "$VERBOSE" = true ]; then
 fi
 
 if [ "$NEW" = true ]; then
+  # new scoped packages need to be set explicitly to public or restricted
+  if [[ "$PACKAGE_NAME" == @* ]]; then
+    if [ -z "$NPM_ACCESS" ]; then
+      echo "$MSG_ERROR: New scoped packages must also set access via the '--public' or '--restricted' flags. Aborting."
+      exit 1
+    fi
+  fi
+
   if [ "$VERBOSE" = true ]; then
     echo "# $MSG_NOTE: skipping owner check"
     echo "# $MSG_WARNING: new package, add more maintainers!"
@@ -283,9 +294,17 @@ if [ $(node -p "'build' in (require('./package.json').scripts || {})") = true ];
   run_cmd npm install
 fi
 if [ x"$TAG" = x ]; then
-  run_cmd npm publish --access public
+  if [ -z "$NPM_ACCESS" ]; then
+    run_cmd npm publish
+  else
+    run_cmd npm publish --access $NPM_ACCESS
+  fi
 else
-  run_cmd npm publish --tag $TAG --access public
+  if [ -z "$NPM_ACCESS" ]; then
+    run_cmd npm publish --tag $TAG
+  else
+    run_cmd npm publish --tag $TAG --access $NPM_ACCESS
+  fi
 fi
 run_cmd cd ${PACKAGE_DIR}
 run_cmd npm version prepatch -m 'Start %s.'


### PR DESCRIPTION
Scoped packages are private by default and one must supply a flag `npm publish --access public` for public scoped packages.

https://docs.npmjs.com/creating-and-publishing-scoped-public-packages
https://docs.npmjs.com/cli/publish

I have not tried having the `--access` flag on with a non-scoped package to see if there's a problem with just having it always active.