### PR TITLE
Skip cloning.

### DIFF
--- a/pubnpm
+++ b/pubnpm
@@ -278,20 +278,22 @@ run_cmd npm version $VERSION_TYPE -m 'Release %s.'
 run_cmd git push
 run_cmd git push --tags
 NEW_VERSION=$(node -p "require('./package.json').version")
-run_cmd cd "${RELEASE_FOLDER}"
-run_cmd rm -rf ${PACKAGE_NAME}
-echo "# $MSG_NOTE: Waiting two seconds..."
-run_cmd sleep 2
-run_cmd git clone $PACKAGE_REPO ${PACKAGE_NAME}
-run_cmd cd ${PACKAGE_NAME}
-if [ $DRY_RUN = true ]; then
-   echo "# $MSG_NOTE: The following version is the old version due to dry-run mode."
-fi
-run_cmd git checkout tags/v${NEW_VERSION}
-# if convention of a "build" target exists, assume an install is needed
-if [ $(node -p "'build' in (require('./package.json').scripts || {})") = true ]; then
-  echo "# $MSG_NOTE: \"build\" script found, running install..."
-  run_cmd npm install
+if [ false = true ]; then
+  run_cmd cd "${RELEASE_FOLDER}"
+  run_cmd rm -rf ${PACKAGE_NAME}
+  echo "# $MSG_NOTE: Waiting two seconds..."
+  run_cmd sleep 2
+  run_cmd git clone $PACKAGE_REPO ${PACKAGE_NAME}
+  run_cmd cd ${PACKAGE_NAME}
+  if [ $DRY_RUN = true ]; then
+    echo "# $MSG_NOTE: The following version is the old version due to dry-run mode."
+  fi
+  run_cmd git checkout tags/v${NEW_VERSION}
+  # if convention of a "build" target exists, assume an install is needed
+  if [ $(node -p "'build' in (require('./package.json').scripts || {})") = true ]; then
+    echo "# $MSG_NOTE: \"build\" script found, running install..."
+    run_cmd npm install
+  fi
 fi
 if [ x"$TAG" = x ]; then
   if [ -z "$NPM_ACCESS" ]; then


### PR DESCRIPTION
The use case is that there are artifact that need to be put into the npm package that are *not* created by any `build` script that is defined in the package.json file.  Those artifacts also are not checked into the github repository.  Therefore, if the repository is cloned, those files are absent and will not be included in the npm tarball.

I propose that we add another flag for `--skip-clone` that will replaces the fake conditional i've added here on L270.