### PR TITLE
Change default branch to main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ pubbower minor
 * `-C` or `--color=WHEN`:  Color mode: always, auto, never (default: `PUBNPM_COLOR` env var or `auto`).
 * `-n` or `--dry-run`: Show commands that will be run without executing them.
 * `-t TAG` or `--tag=TAG`: Use the [npm publish](https://docs.npmjs.com/cli/publish) tag feature
-* `-b BRANCH` or `--branch=BRANCH`: Ensure running on a git branch (default: master, empty string to skip).
+* `-b BRANCH` or `--branch=BRANCH`: Ensure running on a git branch (default: main, empty string to skip).
 * `-N` or `--new`: Skip owner check for a new package.
 * `-P` or `--public`: Used with `new` to specify that a scoped package is public.
 * `-R` or `--restricted`: Used with `new` to specify that a scoped package is private/restricted.
@@ -44,5 +44,10 @@ pubnpm -v -t dev patch
 
 ### Release a new public scoped package from the main branch
 ```sh
-pubnpm -N -P -b main major
+pubnpm -N -P major
+```
+
+### Release a new public scoped package from the master branch
+```sh
+pubnpm -N -P -b master major
 ```

--- a/pubnpm
+++ b/pubnpm
@@ -66,7 +66,7 @@ Options:
   -n, --dry-run  Dry run.
   -t, --tag=TAG  Use npm publish tag.
   -b, --branch=BRANCH
-                 Ensure git branch (default: master, empty string to skip).
+                 Ensure git branch (default: main, empty string to skip).
   -N, --new      Skip owner check for a new package.
   -C, --no-color No colors.
 " 1>&2
@@ -84,7 +84,7 @@ Options:
   -C  Color mode: always, auto, never (default: PUBNPM_COLOR env var or auto).
   -n  Dry run.
   -t  Use npm publish tag.
-  -b  Ensure git branch (default: master, empty string to skip).
+  -b  Ensure git branch (default: main, empty string to skip).
   -N  Skip owner check for a new package.
 " 1>&2
   exit
@@ -119,7 +119,7 @@ fi
 VERBOSE=false
 DRY_RUN=false
 TAG=
-BRANCH=master
+BRANCH=main
 NEW=false
 COLOR=${PUBNPM_COLOR:-auto}
 NPM_ACCESS=

--- a/pubtag
+++ b/pubtag
@@ -62,7 +62,7 @@ Options:
                  Color mode: always, auto, never
                  (default: PUBNPM_COLOR env var or auto).
   -b, --branch=BRANCH
-                 Ensure git branch (default: master, empty string to skip).
+                 Ensure git branch (default: main, empty string to skip).
   -C, --no-color No colors.
 " 1>&2
   exit
@@ -77,7 +77,7 @@ Options:
   -h  Show help.
   -v  Verbose execution.
   -C  Color mode: always, auto, never (default: PUBNPM_COLOR env var or auto).
-  -b  Ensure git branch (default: master, empty string to skip).
+  -b  Ensure git branch (default: main, empty string to skip).
 " 1>&2
   exit
 }
@@ -109,7 +109,7 @@ else
 fi
 
 VERBOSE=false
-BRANCH=master
+BRANCH=main
 COLOR=${PUBNPM_COLOR:-auto}
 
 while true; do


### PR DESCRIPTION
- 'main' is the preferred branch for Digital Bazaar now.
- Better to fail by default if you are on the wrong branch, like an old
  'master' when a 'main' exists.

Providing default branch name alternatives, like mentioned in https://github.com/digitalbazaar/publish-script/issues/24, seems complex and not for much benefit as we move all repos to use 'main'.